### PR TITLE
ORCID + Update

### DIFF
--- a/docs/page.hiveteam.html
+++ b/docs/page.hiveteam.html
@@ -46,7 +46,7 @@
 	Anton Golikov<br>
 	April Yang<br>
 	Arya Eskandarian<br>
-	Charles Hadley King<br>
+	<a href = "https://orcid.org/0000-0003-1409-4549">Charles Hadley King<a><br>
 	Chris Armstrong<br>
 	Daniel Lyman<br>
 	Deepika Prasad<br>

--- a/docs/page.hiveteam.html
+++ b/docs/page.hiveteam.html
@@ -12,7 +12,7 @@
 <tr>
 <td valign=top style="padding:0px 0px 0px 10px;">
 
-<a href="http://www.gwumc.edu/smhs/facultydirectory/profile.cfm?empName=Raja Mazumder&FacID=2067473740" class=blue13>Raja Mazumder</a> (HIVE Lab)
+<a href="https://orcid.org/0000-0001-8823-9945" class=blue13>Raja Mazumder </a> (HIVE Lab) - <a href="http://www.gwumc.edu/smhs/facultydirectory/profile.cfm?empName=Raja Mazumder&FacID=2067473740">Faculty Bio </a>
 <br>
 <class=blue13>Mark Walderhaug</a> (FDA-HIVE)
 
@@ -27,7 +27,7 @@
   <tr>
     <td valign=top style="padding:0px 0px 0px 10px;">
 
-      <a href="https://hive.biochemistry.gwu.edu/dna.cgi?cmd=main-people-vahan-simonyan" class=blue13>Vahan Simonyan</a> (FDA-HIVE)
+    <class=blue13>Vahan Simonyan(FDA-HIVE) - <a href="https://hive.biochemistry.gwu.edu/dna.cgi?cmd=main-people-vahan-simonyan"> Faculty Bio </a> 
     </td>
 </tr>
 </table>
@@ -40,42 +40,52 @@
 
 <tr>
 <td valign=top style="padding:0px 0px 0px 10px;">
-	Alex Nguyen<br>
-	Arya Eskandarian<br>
-	Amanda Bell<br>
+	Alex Coleman<br>
+	Alexander Lukyanov<br>
+	<a href = "https://orcid.org/0000-0002-9920-565X">Amanda Bell</a><br>
 	Anton Golikov<br>
+	April Yang<br>
+	Arya Eskandarian<br>
 	Charles Hadley King<br>
-	Ekaterina Minina<br>
-	Elaine Thompson<br>
-	Evan Holmes<br>
-	Grace Alterovitz<br>
-	Haoqiang Lyu<br>
+	Chris Armstrong<br>
+	Daniel Lyman<br>
+	Deepika Prasad<br>
+	Dipankar Chattopadhyay<br>
+	Hasmik Manukyan<br>
 	Hayley Dingerdissen<br>
-	Hiral Desai<br>
 	Ilya Mazo<br>
+	James Ziegler<br>
+	<a href = "https://orcid.org/0000-0002-8824-4637">Janisha Patel</a><br>
 	Jeet Kiran Vora<br>
-	Janisha Patel<br>
-	John Torcivia<br> 
+	John Dougherty<br>
+	John Torcivia<br>
+	Jonathon Keeney<br>
+	Kamil Kural<br>
+	<a href = "https://orcid.org/0000-0002-4776-5137">Konstantinos Karagiannis</a><br>
 </td>
 
 <td valign=top>
-	Jonathon Keeney<br>
-	Krista Smith<br>
+	<a href = "https://orcid.org/0000-0001-8084-9570">Krista Smith</a><br>
+	Lindsay Hopson<br>
 	Luis Santana-Quintero<br>
 	Marianna Faradzheva<br>
-	Michael Joseph<br>
+	Marla Surette<br>
 	Nagarajan Pattabiraman<br>
 	Naila Gulzar<br>
+	Ned Cauley<br>
+	<a href = "https://orcid.org/0000-0003-2050-5084">Nikhita Gogate</a><br>
 	Rahi Navelkar<br>
 	Robel Kahsay<br>
+	Sean Smith<br>
 	Sergey Ivanovsky<br>
-	Sneh Talwar<br>
-	Stephanie Singleton<br>
+	<a href = "https://orcid.org/0000-0003-0256-9834">Stephanie Singleton</a><br>
 	Sydney Fenstermaker<br>
+	Tianyi Wang<br>
 	Tigran Ghazanchyan<br>
-	Xavier Holmes<br>
-	Yao Ren<br>
-	Zara Airapetian<br>
+	Viswanadham Sridhara<br>
+	Vyacheslav Furtak<br>
+	Wei-Lun Alterovitz<br>
+	Xiying Ding<br>
 </td>
 </tr>
 </table>
@@ -86,9 +96,9 @@
 <table width=100% border=0>
 <tr>
 <td valign=top style="padding:0px 0px 0px 10px;">
-
-	Alexandre Rostovtsev<br>
 	Aleksey Pshenichnov<br>
+	Alex Nguyen<br>
+	Alexandre Rostovtsev<br>
 	Alin Voskanian<br>
 	Amanraj Singh<br>
 	Amir Shams<br>
@@ -96,20 +106,30 @@
 	Brian Fochtman<br>
 	Charles Cole<br>
 	Cheng Yan<br>
+	Ekaterina Minina<br>
+	Elaine Thompson<br>
+	Evan Holmes<br>
+	Grace Alterovitz<br>
+	Haoqiang Lyu<br>
+	Hiral Desai<br>
 	Jamie Faison<br>
 	John Jackson<br>
 	Julie Yu<br>
 	Konstantinos Karagiannis<br>
-	Michelle Shen<br>Mona Motwani<br>
-	Monica Sharma<br>Nicole Ferrer<br>
+	Michael Joseph<br>
+	Michelle Shen<br>
+	Mona Motwani<br>
+	Monica Sharma<br>
+	Nicole Ferrer<br>
 	Olesja Muravitskaja<br>
-	Olga Golikova<br>P
-	huc VinhNguyen Lam<br>
+	Olga Golikova<br>
+	Phuc VinhNguyen Lam<br>
 	Prince Birring<br>
 	Quan Wan<br>
 	Rahul Sethi<br>
 	Reza Mousavi<br>
 	Scott Goldweber<br>
+	Sneh Talwar<br>
 	Sohum Thakkar<br>
 	Stefan Dabic<br>
 	Tejas Narsule<br>
@@ -117,11 +137,12 @@
 	Tsung-Jung Wu<br>
 	Valerii Soika<br>
 	Valery Tkachenko<br>
+	Xavier Holmes<br>
 	Yang Pan<br>
-	Yu Hu<br>
+	Yao Ren<br>
 	Yu Fan<br>
-</td>
+	Yu Hu<br>
+	Zara Airapetian<br>
+	</td>
 </tr>
 </table>
-
-


### PR DESCRIPTION
Added 
•	Alex Coleman
•	Alexander Lukyanov
•	April Yang
•	Chris Armstrong
•	Daniel Lyman
•	Deepika Prasad
•	Dipankar Chattopadhyay
•	Hasmik Manukyan
•	James Ziegler
•	John Dougherty
•	Kamil Kural
•	Konstantinos Karagiannis
•	Lindsay Hopson
•	Marla Surette
•	Ned Cauley
•	Sean Smith
•	Tianyi Wang
•	Viswanadham Sridhara
•	Vyacheslav Furtak
•	Wei-Lun Alterovitz
•	Xiying Ding
 to current members
Moved 
•	Alex Nguyen
•	Ekaterina Minina
•	Elaine Thompson
•	Evan Holmes
•	Grace Alterovitz
•	Haoqiang Lyu
•	Hiral Desai
•	Michael Joseph
•	Xavier Holmes
•	Yao Ren
•	Zara Airapetian
to lab alumni

Added ORCIDS for 

•	Raja Mazumder
•	Amanda Bell 
•	Janisha Patel 
•	Hadley King 
•	Nikhita Gogate 
•	Stephanie Singleton  
•	Konstantinos Karagiannis
•	Luis Santana
•	Krista Smith

Moved faculty bio for Raja and Vahan as a hyperlink next to their name, in order for the hyperlink on the name go to ORCID to avoid confusion.

@Uncreative-Username-Generator
Uncreative-Username-Generat